### PR TITLE
correct the list of observed attributes

### DIFF
--- a/life-cycle-callbacks/main.js
+++ b/life-cycle-callbacks/main.js
@@ -3,7 +3,7 @@ class Square extends HTMLElement {
   // Specify observed attributes so that
   // attributeChangedCallback will work
   static get observedAttributes() {
-    return ['w', 'l'];
+    return ['c', 'l'];
   }
 
   constructor() {


### PR DESCRIPTION
In the life-cycle-callbacks example, the `static get observedAttributes()` function was returning attributes `w` and `l`, but the custom element actually uses `c` and `l`; thus, an update to the color would not be observed.