### PR TITLE
Close <popup-info> correctly

### DIFF
--- a/popup-info-box-web-component/index.html
+++ b/popup-info-box-web-component/index.html
@@ -9,7 +9,7 @@
 
     <form>
       <div>
-        <label for="cvc">Enter your CVC <popup-info img="img/alt.png" data-text="Your card validation code (CVC) is an extra security feature — it is the last 3 or 4 numbers on the back of your card."></label>
+        <label for="cvc">Enter your CVC <popup-info img="img/alt.png" data-text="Your card validation code (CVC) is an extra security feature — it is the last 3 or 4 numbers on the back of your card."></popup-info></label>
         <input type="text" id="cvc">
       </div>
     </form>


### PR DESCRIPTION
Custom elements must be closed for the HTML to be valid. https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements should be updated accordingly.