### PR TITLE
ExpandingList element made more self-contained

### DIFF
--- a/expanding-list-web-component/index.html
+++ b/expanding-list-web-component/index.html
@@ -70,6 +70,13 @@
             </ul>
         </li>
     </ul>
+    
+    <ul>
+        <li>Not</li>
+        <li>an</li>
+        <li>expanding</li>
+        <li>list</li>
+    </ul>
 
     <script src="main.js"></script>
 </body>

--- a/expanding-list-web-component/main.js
+++ b/expanding-list-web-component/main.js
@@ -2,48 +2,61 @@
 class ExpandingList extends HTMLUListElement {
   constructor() {
     // Always call super first in constructor
-    super();
+    // Return value from super() is a reference to this element
+    self = super();
 
-    window.onload = function() {
-      const uls = Array.from(document.querySelectorAll(':root ul'));
-      const lis = Array.from(document.querySelectorAll(':root li'));
+    // Get ul and li elements that are a child of this custom ul element
+    // li elements can be containers if they have uls within them
+    const uls = Array.from(self.querySelectorAll('ul'));
+    const lis = Array.from(self.querySelectorAll('li'));
 
-      uls.slice(1).forEach(ul => {
-        ul.style.display = 'none';
-      });
+    // Hide all child uls
+    // These lists will be shown when the user clicks a higher level container
+    uls.forEach(ul => {
+      ul.style.display = 'none';
+    });
 
-      lis.forEach(li => {
+        // Look through each li element in the ul
+    lis.forEach(li => {
+      // If this li has a ul as a child, decorate it and add a click handler
+      if (li.querySelectorAll('ul').length > 0) {
+        // Add an attribute which can be used  by the style
+        // to show an open or closed icon
+        li.setAttribute('class', 'closed');
+
+        // Wrap the li element's text in a new span element
+        // so we can assign style and event handlers to the span
         const childText = li.childNodes[0];
         const newSpan = document.createElement('span');
 
+        // Copy text from li to span, set cursor style
         newSpan.textContent = childText.textContent;
+        newSpan.style.cursor = 'pointer';
+        
+        // Add click handler to this span
+        newSpan.onclick = self.showul;
+        
+        // Add the span and remove the bare text node from the li
         childText.parentNode.insertBefore(newSpan, childText);
         childText.parentNode.removeChild(childText);
-      });
-
-      const spans = Array.from(document.querySelectorAll(':root span'));
-
-      spans.forEach(span => {
-        if (span.nextElementSibling) {
-          span.style.cursor = 'pointer';
-          span.parentNode.setAttribute('class', 'closed');
-          span.onclick = showul;
-        }
-      });
-
-      function showul(e) {
-        const nextul = e.target.nextElementSibling;
-
-        if (nextul.style.display == 'block') {
-          nextul.style.display = 'none';
-          nextul.parentNode.setAttribute('class', 'closed');
-        } else {
-          nextul.style.display = 'block';
-          nextul.parentNode.setAttribute('class', 'open');
-        }
       }
-    };
+    });
   }
+
+  // li click handler
+  showul = function (e) {
+    // next sibling to the span should be the ul
+    const nextul = e.target.nextElementSibling;
+
+    // Toggle visible state and update class attribute on ul
+    if (nextul.style.display == 'block') {
+      nextul.style.display = 'none';
+      nextul.parentNode.setAttribute('class', 'closed');
+    } else {
+      nextul.style.display = 'block';
+      nextul.parentNode.setAttribute('class', 'open');
+    }
+  };
 }
 
 // Define the new element


### PR DESCRIPTION
I have been away from JavaScript for awhile and was checking out Web Components.  I had a lot of trouble following this example until I realized it would make changes to DOM elements not related to the customized element, and thus was leaky encapsulation.  I modified the example element to be re-usable multiple times on the same page and to not interfere with ULs that are not of the customized type.

Added self variable to constructor and modified element
queries to base off self instead of document.
Element queries for lis and uls were run on the document
variable, and would modify ULs that were not children
of the customized ul element, and even modify ULs that were
did not specify is="expanding-list"

Merged creation of spans and the adding for click handler
and decoration to the spans.

Eliminated setting window.onload

Added a ul to index.html that is NOT and ExpandingList to show
that it is not affected by the code in the web component
definition

Added numerous comments explaining code purpose.