### PR TITLE
Ignore leading and trailing spaces

### DIFF
--- a/word-count-web-component/main.js
+++ b/word-count-web-component/main.js
@@ -9,7 +9,8 @@ class WordCount extends HTMLParagraphElement {
 
     function countWords(node){
       const text = node.innerText || node.textContent;
-      return text.split(/\s+/g).length;
+      // ignore leading and trailing spaces in word count
+      return text.trim().split(/\s+/g).length;
     }
 
     const count = `Words: ${countWords(wcParent)}`;


### PR DESCRIPTION
Text must be trimmed before being split by spaces, otherwise trailing or leading spaces will add spurious word counts.
