### PR TITLE
fix Element.shadow example bug #13454

### DIFF
--- a/word-count-web-component/main.js
+++ b/word-count-web-component/main.js
@@ -9,7 +9,7 @@ class WordCount extends HTMLParagraphElement {
 
     function countWords(node){
       const text = node.innerText || node.textContent;
-      return text.split(/\s+/g).length;
+      return text.trim().split(/\s+/g).filter(a => a.trim().length > 0).length;
     }
 
     const count = `Words: ${countWords(wcParent)}`;


### PR DESCRIPTION
#### Summary

[fixes #13454](https://github.com/mdn/content/issues/13454) - fixes function `countWords` where for empty strings it returns 0 instead of 1.

This PR…
-->

 - [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error