### PR TITLE
fix PopUpInfo

### DIFF
--- a/popup-info-box-web-component/main.js
+++ b/popup-info-box-web-component/main.js
@@ -70,9 +70,9 @@ class PopUpInfo extends HTMLElement {
     `;
 
     // Attach the created elements to the shadow dom
-    this.shadow.appendChild(style);
+    this.shadowRoot.appendChild(style);
     console.log(style.isConnected);
-    this.shadow.appendChild(wrapper);
+    this.shadowRoot.appendChild(wrapper);
     wrapper.appendChild(icon);
     wrapper.appendChild(info);
   }

--- a/popup-info-box-web-component/main.js
+++ b/popup-info-box-web-component/main.js
@@ -5,8 +5,9 @@ class PopUpInfo extends HTMLElement {
     super();
 
     // Create a shadow root
-    const shadow = this.attachShadow({mode: 'open'});
-
+    this.attachShadow({mode: 'open'});
+  }
+  connectedCallback() {
     // Create spans
     const wrapper = document.createElement('span');
     wrapper.setAttribute('class', 'wrapper');
@@ -69,9 +70,9 @@ class PopUpInfo extends HTMLElement {
     `;
 
     // Attach the created elements to the shadow dom
-    shadow.appendChild(style);
+    this.shadow.appendChild(style);
     console.log(style.isConnected);
-    shadow.appendChild(wrapper);
+    this.shadow.appendChild(wrapper);
     wrapper.appendChild(icon);
     wrapper.appendChild(info);
   }


### PR DESCRIPTION
#### Summary
Fix the PopUp Info Custom Element's code.

#### Supporting details
With this bug, we cannot use `this.getAttributes()`.
So this code is not working.

We must use this method after the element's connection to the DOM.
This is why I put the part after the creation of the shadow root inside the `connectedCallback()` method.

#### Related content pull request
[The PR in the mdn/content](https://github.com/mdn/content/pull/19035)
