### PR TITLE
Remove invalid closing tag from editable-list

### DIFF
--- a/editable-list/main.js
+++ b/editable-list/main.js
@@ -48,7 +48,7 @@
         </ul>
         <div>
           <label>${addItemText}</label>
-          <input class="add-new-list-item-input" type="text"></input>
+          <input class="add-new-list-item-input" type="text">
           <button class="editable-list-add-item icon">&oplus;</button>
         </div>
       `;


### PR DESCRIPTION
#### Summary
Remove invalid closing tag from editable-list

#### Supporting details
https://html.spec.whatwg.org/multipage/input.html#the-input-element

#### Related content pull request
I could not find any relevant documentation on the [/mdn/content repository](https://github.com/mdn/content)
