### PR TITLE
Update main.js

### DIFF
--- a/host-selectors/main.js
+++ b/host-selectors/main.js
@@ -14,7 +14,6 @@ class ContextSpan extends HTMLElement {
         span:hover { text-decoration: underline; }
         :host-context(h1) { font-style: italic; }
         :host-context(h1):after { content: " - no links in headers!" }
-        :host-context(article, aside) { color: gray; }
         :host(.footer) { color : red; }
         :host { background: rgba(0,0,0,0.1); padding: 2px 5px; }
       `;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed invalid statement from live example.

#### Syntax from Docs

```css-nolint
:host-context(<compound-selector>) {
  /* ... */
}
```

#### Invalid Examples

```css
:host-context(article, aside) { color: gray; }
```

This is not valid because the argument provided to the `:host-context()` pseudo-class function is not a `<compound-selector>`. Rather, it is a "selector list" which is invalid and does not work in the live example.

```css
:host-context(main article) {
  font-weight: bold;
}
```

This is not valid because the argument provided to the `:host-context()` pseudo-class function is not a `<compound-selector>`. Rather, it is a `<complex-selector>` which is invalid and does not work in the live example.

This is explained in the [Structure of a Selector - CSS Selectors - MDN Docs Page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors#structure_of_a_selector)

### Motivation

The invalid CSS caused confusion when looking at the [live example](https://mdn.github.io/web-components-examples/host-selectors/)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

