### PR TITLE
use input event listener for word counter example closes #51

### DIFF
--- a/word-count-web-component/main.js
+++ b/word-count-web-component/main.js
@@ -25,10 +25,9 @@ class WordCount extends HTMLParagraphElement {
     shadow.appendChild(text);
 
     // Update count when element content changes
-    setInterval(function() {
-      const count = `Words: ${countWords(wcParent)}`;
-      text.textContent = count;
-    }, 200);
+    this.parentNode.addEventListener('input', () => {
+      text.textContent = 'Words: ' + countWords(wcParent);
+    });
   }
 }
 

--- a/word-count-web-component/main.js
+++ b/word-count-web-component/main.js
@@ -26,7 +26,7 @@ class WordCount extends HTMLParagraphElement {
 
     // Update count when element content changes
     this.parentNode.addEventListener('input', () => {
-      text.textContent = 'Words: ' + countWords(wcParent);
+      text.textContent = `Words: ${countWords(wcParent)}`;
     });
   }
 }


### PR DESCRIPTION
Word counter example
As mentioned in the issue instead of using setInterval we can use input event listener.

Closes #51 
